### PR TITLE
Remove redundant build tags

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "safeopen_nix_common.go",
         "safeopen_linux.go",
         "safeopen_nix.go",
-        "safeopen_win.go",
+        "safeopen_windows.go",
     ],
     importpath = "github.com/google/safeopen",
     visibility = ["//visibility:public"],
@@ -46,7 +46,7 @@ go_test(
       "safeopen_test.go",
       "safeopen_linux_test.go",
       "safeopen_nix_test.go",
-      "safeopen_win_test.go",
+      "safeopen_windows_test.go",
     ],
     embed = [":safeopen"],
 )

--- a/safeopen_linux.go
+++ b/safeopen_linux.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package safeopen
 
 import (

--- a/safeopen_linux_test.go
+++ b/safeopen_linux_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build linux
-// +build linux
-
 package safeopen
 
 import (

--- a/safeopen_nix.go
+++ b/safeopen_nix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unix && !linux
-// +build unix,!linux
 
 package safeopen
 

--- a/safeopen_nix_common.go
+++ b/safeopen_nix_common.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unix
-// +build unix
 
 package safeopen
 

--- a/safeopen_nix_test.go
+++ b/safeopen_nix_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build unix
-// +build unix
 
 package safeopen
 

--- a/safeopen_windows.go
+++ b/safeopen_windows.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build windows
-// +build windows
-
 package safeopen
 
 import (

--- a/safeopen_windows_test.go
+++ b/safeopen_windows_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build windows
-// +build windows
-
 package safeopen
 
 import (


### PR DESCRIPTION
This PR removes outdated in Go 1.21 `// +build` comments by running the command:
```
go fix -fix buildtag ./...
```

From https://pkg.go.dev/cmd/go@go1.21.0#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

As the file name ends with `_linux.go` or `_windows.go`, we don't need `//go:build linux` and `//go:build windows` according to the documentation.